### PR TITLE
Feat/set defaults for l2 veto

### DIFF
--- a/e2e/scripts/deploySetup.ts
+++ b/e2e/scripts/deploySetup.ts
@@ -136,7 +136,7 @@ async function main() {
       token: zkToken.address,
       timelock: zeroAddress,
       initialVotingDelay: 0,
-      initialVotingPeriod: 100,
+      initialVotingPeriod: 10000,
       initialProposalThreshold: 0,
       initialQuorum: 0,
       initialVoteExtension: 0,
@@ -163,10 +163,10 @@ async function main() {
   console.log("ZkTokenGovernor deployed to:", zkTokenGovernor.address);
 
   await zkGovOpsGovernor.write.propose([[zeroAddress], [0n], ["0x"], "Test GovOps proposal"]);
-  // await zkTokenGovernor.write.propose([[zeroAddress], [0n], ["0x"], "Test Token proposal"]);
+  await zkTokenGovernor.write.propose([[zeroAddress], [1n], ["0x"], "Test Token proposal"]);
 
   addressesContent += `ZkGovOpsGovernor: ${zkGovOpsGovernor.address}\n`;
-  // addressesContent += `ZkTokenGovernor: ${zkTokenGovernor.address}\n`;
+  addressesContent += `ZkTokenGovernor: ${zkTokenGovernor.address}\n`;
 
   const calldata = encodeFunctionData({
     abi: counterAbi,

--- a/webapp/app/.server/service/l2-cancellations.ts
+++ b/webapp/app/.server/service/l2-cancellations.ts
@@ -34,7 +34,7 @@ const eventSchema = z.object({
 });
 
 function blocksInADay() {
-  if (env.ETH_NETWORK === "mainnet") {
+  if (env.ETH_NETWORK === "mainnet" || env.ETH_NETWORK === "local") {
     return 24 * 3600; // 24 hours, 1 block per second
   }
   return 24 * (3600 / 20); // 20 seconds per block.

--- a/webapp/app/routes/app/l2-cancellations/$id/exec-l2-veto-form.tsx
+++ b/webapp/app/routes/app/l2-cancellations/$id/exec-l2-veto-form.tsx
@@ -129,7 +129,7 @@ export default function ExecL2VetoForm({
   const form = useForm<SubmitType>({
     resolver: zodResolver(submitSchema),
     defaultValues: {
-      value: "0.001"
+      value: "0.001",
     },
     mode: "onTouched",
   });

--- a/webapp/app/routes/app/l2-cancellations/$id/exec-l2-veto-form.tsx
+++ b/webapp/app/routes/app/l2-cancellations/$id/exec-l2-veto-form.tsx
@@ -128,7 +128,9 @@ export default function ExecL2VetoForm({
 
   const form = useForm<SubmitType>({
     resolver: zodResolver(submitSchema),
-    defaultValues: {},
+    defaultValues: {
+      value: "0.001"
+    },
     mode: "onTouched",
   });
 

--- a/webapp/app/routes/app/l2-cancellations/new/_route.tsx
+++ b/webapp/app/routes/app/l2-cancellations/new/_route.tsx
@@ -100,7 +100,7 @@ export default function NewL2GovernorVeto() {
     defaultValues: {
       nonce: suggestedNonce,
       l2GasLimit: 80000000,
-      l2GasPerPubdataByteLimit: 60000,
+      l2GasPerPubdataByteLimit: 800,
       refundRecipient: address,
       txMintValue: 1000000000000000,
     },

--- a/webapp/app/routes/app/l2-cancellations/new/_route.tsx
+++ b/webapp/app/routes/app/l2-cancellations/new/_route.tsx
@@ -30,8 +30,8 @@ import { useForm } from "react-hook-form";
 import { getFormData } from "remix-params-helper";
 import { $path } from "remix-routes";
 import { numberToHex } from "viem";
-import { z } from "zod";
 import { useAccount } from "wagmi";
+import { z } from "zod";
 
 export async function loader() {
   return defer({ activeL2Proposals: getActiveL2Proposals() });
@@ -74,7 +74,7 @@ type Schema = z.infer<typeof schema>;
 
 export default function NewL2GovernorVeto() {
   const { activeL2Proposals } = useLoaderData<typeof loader>();
-  const {address} =  useAccount();
+  const { address } = useAccount();
 
   const form = useForm<Schema>({
     resolver: zodResolver(schema),
@@ -82,7 +82,7 @@ export default function NewL2GovernorVeto() {
       l2GasLimit: 600000,
       l2GasPerPubdataByteLimit: 60000,
       refundRecipient: address,
-      txMintValue: 1000000000000000
+      txMintValue: 1000000000000000,
     },
     mode: "onTouched",
   });

--- a/webapp/app/routes/app/l2-cancellations/new/_route.tsx
+++ b/webapp/app/routes/app/l2-cancellations/new/_route.tsx
@@ -79,7 +79,7 @@ export default function NewL2GovernorVeto() {
   const form = useForm<Schema>({
     resolver: zodResolver(schema),
     defaultValues: {
-      l2GasLimit: 600000,
+      l2GasLimit: 80000000,
       l2GasPerPubdataByteLimit: 60000,
       refundRecipient: address,
       txMintValue: 1000000000000000,

--- a/webapp/app/routes/app/l2-cancellations/new/_route.tsx
+++ b/webapp/app/routes/app/l2-cancellations/new/_route.tsx
@@ -31,6 +31,7 @@ import { getFormData } from "remix-params-helper";
 import { $path } from "remix-routes";
 import { numberToHex } from "viem";
 import { z } from "zod";
+import { useAccount } from "wagmi";
 
 export async function loader() {
   return defer({ activeL2Proposals: getActiveL2Proposals() });
@@ -71,13 +72,18 @@ const schema = z.object({
 });
 type Schema = z.infer<typeof schema>;
 
-const defaultValues = {};
-
 export default function NewL2GovernorVeto() {
   const { activeL2Proposals } = useLoaderData<typeof loader>();
+  const {address} =  useAccount();
+
   const form = useForm<Schema>({
     resolver: zodResolver(schema),
-    defaultValues,
+    defaultValues: {
+      l2GasLimit: 600000,
+      l2GasPerPubdataByteLimit: 60000,
+      refundRecipient: address,
+      txMintValue: 1000000000000000
+    },
     mode: "onTouched",
   });
   const navigation = useNavigation();


### PR DESCRIPTION
Added defaults for l2 veto creation:

- **L2 gas limit:** 8000000
- **L2 gas per pubdata:** 800
- **Refund recipient:** current connected wallet
- **Transaction mint value:** 1000000000000000
- **Default amount of eth in broadcast tx:** 0.001


