### PR TITLE
using right cancellation type.

### DIFF
--- a/webapp/app/.server/service/l2-cancellations.ts
+++ b/webapp/app/.server/service/l2-cancellations.ts
@@ -182,7 +182,7 @@ export async function createVetoProposalFor(
         externalId: proposalData.proposalId,
         proposer: proposalData.proposer,
         description: proposalData.description,
-        type: "ZK_GOV_OPS_GOVERNOR",
+        type: proposalData.type,
         nonce: Number(nonce),
         status: l2CancellationStatusEnum.enum.ACTIVE,
         txRequestGasLimit: l2GasLimit,


### PR DESCRIPTION
This is causing only display confusion. The data needed to create the transaction is being set ok.
Changing already created proposals is not urgent.