### PR TITLE
Fix/avoid multiple vetos with the same nonce

### DIFF
--- a/e2e/scripts/deploySetup.ts
+++ b/e2e/scripts/deploySetup.ts
@@ -136,7 +136,7 @@ async function main() {
       token: zkToken.address,
       timelock: zeroAddress,
       initialVotingDelay: 0,
-      initialVotingPeriod: 100,
+      initialVotingPeriod: 100000,
       initialProposalThreshold: 0,
       initialQuorum: 0,
       initialVoteExtension: 0,
@@ -151,7 +151,7 @@ async function main() {
       token: zkToken.address,
       timelock: zeroAddress,
       initialVotingDelay: 0,
-      initialVotingPeriod: 100,
+      initialVotingPeriod: 100000,
       initialProposalThreshold: 0,
       initialQuorum: 0,
       initialVoteExtension: 0,
@@ -163,10 +163,15 @@ async function main() {
   console.log("ZkTokenGovernor deployed to:", zkTokenGovernor.address);
 
   await zkGovOpsGovernor.write.propose([[zeroAddress], [0n], ["0x"], "Test GovOps proposal"]);
-  // await zkTokenGovernor.write.propose([[zeroAddress], [0n], ["0x"], "Test Token proposal"]);
+  await zkTokenGovernor.write.propose([
+    [zeroAddress, zeroAddress],
+    [0n, 0n],
+    ["0x", "0x"],
+    "Test Token proposal",
+  ]);
 
   addressesContent += `ZkGovOpsGovernor: ${zkGovOpsGovernor.address}\n`;
-  // addressesContent += `ZkTokenGovernor: ${zkTokenGovernor.address}\n`;
+  addressesContent += `ZkTokenGovernor: ${zkTokenGovernor.address}\n`;
 
   const calldata = encodeFunctionData({
     abi: counterAbi,

--- a/webapp/app/.server/db/dto/l2-cancellations.ts
+++ b/webapp/app/.server/db/dto/l2-cancellations.ts
@@ -1,7 +1,7 @@
-import { type InferInsertModel, type InferSelectModel, eq } from "drizzle-orm";
+import { eq, type InferInsertModel, type InferSelectModel } from "drizzle-orm";
 import type { Hex } from "viem";
 import { db } from "..";
-import { l2CancellationStatusEnum, l2CancellationsTable } from "../schema";
+import { l2CancellationsTable } from "../schema";
 import { createOrIgnoreRecord, getFirst, getFirstOrThrow } from "./utils/common";
 
 export async function createOrIgnoreL2Cancellation(
@@ -11,11 +11,10 @@ export async function createOrIgnoreL2Cancellation(
   return createOrIgnoreRecord(l2CancellationsTable, data, { tx }).then(getFirst);
 }
 
-export async function getActiveL2Cancellations({ tx }: { tx: typeof db } = { tx: db }) {
+export async function getL2Cancellations({ tx }: { tx: typeof db } = { tx: db }) {
   return tx
     .select()
     .from(l2CancellationsTable)
-    .where(eq(l2CancellationsTable.status, l2CancellationStatusEnum.enum.ACTIVE));
 }
 
 export async function getL2CancellationById(

--- a/webapp/app/.server/db/dto/l2-cancellations.ts
+++ b/webapp/app/.server/db/dto/l2-cancellations.ts
@@ -1,7 +1,7 @@
-import { type InferInsertModel, type InferSelectModel, eq } from "drizzle-orm";
+import { type InferInsertModel, type InferSelectModel, eq, max, and } from "drizzle-orm";
 import type { Hex } from "viem";
 import { db } from "..";
-import { l2CancellationsTable } from "../schema";
+import { l2CancellationsTable, l2CancellationStatusEnum } from "../schema";
 import { createOrIgnoreRecord, getFirst, getFirstOrThrow } from "./utils/common";
 
 export async function createOrIgnoreL2Cancellation(

--- a/webapp/app/.server/db/dto/l2-cancellations.ts
+++ b/webapp/app/.server/db/dto/l2-cancellations.ts
@@ -1,4 +1,4 @@
-import { eq, type InferInsertModel, type InferSelectModel } from "drizzle-orm";
+import { type InferInsertModel, type InferSelectModel, eq } from "drizzle-orm";
 import type { Hex } from "viem";
 import { db } from "..";
 import { l2CancellationsTable } from "../schema";
@@ -12,9 +12,7 @@ export async function createOrIgnoreL2Cancellation(
 }
 
 export async function getL2Cancellations({ tx }: { tx: typeof db } = { tx: db }) {
-  return tx
-    .select()
-    .from(l2CancellationsTable)
+  return tx.select().from(l2CancellationsTable);
 }
 
 export async function getL2CancellationById(

--- a/webapp/app/.server/db/dto/l2-cancellations.ts
+++ b/webapp/app/.server/db/dto/l2-cancellations.ts
@@ -54,7 +54,7 @@ export async function getMaxRegisteredNonce(): Promise<number | null> {
     .select({ value: max(l2CancellationsTable.nonce) })
     .from(l2CancellationsTable)
     .then(getFirst);
-  return row ? Number(row.value) : null;
+  return row && row.value !== null ? Number(row.value) : null;
 }
 
 export async function existActiveProposalWithNonce(nonce: number): Promise<boolean> {

--- a/webapp/app/.server/db/schema.ts
+++ b/webapp/app/.server/db/schema.ts
@@ -151,7 +151,7 @@ export const l2CancellationTypeEnum = z.enum(["ZK_GOV_OPS_GOVERNOR", "ZK_TOKEN_G
 
 export type L2CancellationType = z.infer<typeof l2CancellationTypeEnum>;
 
-export const l2CancellationStatusEnum = z.enum(["ACTIVE", "DONE", "CANCELED"]);
+export const l2CancellationStatusEnum = z.enum(["ACTIVE", "DONE", "NONCE_TOO_LOW", "EXPIRED"]);
 
 export const l2CancellationsTable = pgTable("l2_governor_cancellations", {
   id: serial("id").primaryKey(),

--- a/webapp/app/.server/db/schema.ts
+++ b/webapp/app/.server/db/schema.ts
@@ -151,7 +151,7 @@ export const l2CancellationTypeEnum = z.enum(["ZK_GOV_OPS_GOVERNOR", "ZK_TOKEN_G
 
 export type L2CancellationType = z.infer<typeof l2CancellationTypeEnum>;
 
-export const l2CancellationStatusEnum = z.enum(["ACTIVE", "DONE", "NONCE_TOO_LOW", "EXPIRED"]);
+export const l2CancellationStatusEnum = z.enum(["ACTIVE", "DONE", "NONCE_TOO_LOW", "L2_PROPOSAL_EXPIRED"]);
 
 export const l2CancellationsTable = pgTable("l2_governor_cancellations", {
   id: serial("id").primaryKey(),

--- a/webapp/app/.server/db/schema.ts
+++ b/webapp/app/.server/db/schema.ts
@@ -151,7 +151,12 @@ export const l2CancellationTypeEnum = z.enum(["ZK_GOV_OPS_GOVERNOR", "ZK_TOKEN_G
 
 export type L2CancellationType = z.infer<typeof l2CancellationTypeEnum>;
 
-export const l2CancellationStatusEnum = z.enum(["ACTIVE", "DONE", "NONCE_TOO_LOW", "L2_PROPOSAL_EXPIRED"]);
+export const l2CancellationStatusEnum = z.enum([
+  "ACTIVE",
+  "DONE",
+  "NONCE_TOO_LOW",
+  "L2_PROPOSAL_EXPIRED",
+]);
 
 export const l2CancellationsTable = pgTable("l2_governor_cancellations", {
   id: serial("id").primaryKey(),

--- a/webapp/app/.server/service/l2-cancellations.ts
+++ b/webapp/app/.server/service/l2-cancellations.ts
@@ -10,7 +10,6 @@ import { bigIntMax } from "@/utils/bigint";
 import { badRequest, notFound } from "@/utils/http";
 import {
   type L2_CANCELLATION_STATES,
-  VALID_CANCELLATION_STATES,
   isValidCancellationState,
 } from "@/utils/l2-cancellation-states";
 import { ALL_ABIS, ZK_GOV_OPS_GOVERNOR_ABI } from "@/utils/raw-abis";
@@ -305,13 +304,13 @@ async function upgradeCancellationStatus(
   if (!isValidCancellationState(state)) {
     cancellation.status = l2CancellationStatusEnum.enum.L2_PROPOSAL_EXPIRED;
     await updateL2Cancellation(cancellation.id, cancellation);
-    return cancellation
+    return cancellation;
   }
 
   if (cancellation.nonce < currentNonce) {
     cancellation.status = l2CancellationStatusEnum.enum.NONCE_TOO_LOW;
     await updateL2Cancellation(cancellation.id, cancellation);
-    return cancellation
+    return cancellation;
   }
 
   return cancellation;

--- a/webapp/app/.server/service/l2-cancellations.ts
+++ b/webapp/app/.server/service/l2-cancellations.ts
@@ -150,9 +150,7 @@ async function fetchProposalsFromL2Governor(type: L2CancellationType, from: bigi
     activeProposals.map((p) => getL2ProposalState(p.type, p.proposalId))
   );
 
-  return activeProposals.filter((_, i) =>
-    VALID_CANCELLATION_STATES.some((state) => state === states[i])
-  );
+  return activeProposals.filter((_, i) => isValidCancellationState(states[i]));
 }
 
 export async function getActiveL2Proposals() {

--- a/webapp/app/.server/service/l2-cancellations.ts
+++ b/webapp/app/.server/service/l2-cancellations.ts
@@ -305,11 +305,13 @@ async function upgradeCancellationStatus(
   if (!isValidCancellationState(state)) {
     cancellation.status = l2CancellationStatusEnum.enum.L2_PROPOSAL_EXPIRED;
     await updateL2Cancellation(cancellation.id, cancellation);
+    return cancellation
   }
 
   if (cancellation.nonce < currentNonce) {
     cancellation.status = l2CancellationStatusEnum.enum.NONCE_TOO_LOW;
     await updateL2Cancellation(cancellation.id, cancellation);
+    return cancellation
   }
 
   return cancellation;

--- a/webapp/app/.server/service/l2-cancellations.ts
+++ b/webapp/app/.server/service/l2-cancellations.ts
@@ -305,7 +305,7 @@ async function upgradeCancellationStatus(
 
   const state = await getL2ProposalState(cancellation.type, cancellation.externalId);
   if (!isValidCancellationState(state)) {
-    cancellation.status = l2CancellationStatusEnum.enum.EXPIRED;
+    cancellation.status = l2CancellationStatusEnum.enum.L2_PROPOSAL_EXPIRED;
     await updateL2Cancellation(cancellation.id, cancellation);
   }
 

--- a/webapp/app/routes/app/l2-cancellations/$id/_route.tsx
+++ b/webapp/app/routes/app/l2-cancellations/$id/_route.tsx
@@ -1,13 +1,10 @@
 import { getl2CancellationCallsByProposalId } from "@/.server/db/dto/l2-cancellation-calls";
-import {
-  getL2CancellationByExternalId,
-  getL2CancellationById,
-} from "@/.server/db/dto/l2-cancellations";
+import { getL2CancellationById } from "@/.server/db/dto/l2-cancellations";
 import { getSignaturesByL2CancellationId } from "@/.server/db/dto/signatures";
 import { guardiansAddress } from "@/.server/service/contracts";
 import {
-  getAndUpdateL2Cancellation,
-  getL2GovernorAddress
+  getAndUpdateL2CancellationByExternalId,
+  getL2GovernorAddress,
 } from "@/.server/service/l2-cancellations";
 import { validateAndSaveL2CancellationSignature } from "@/.server/service/signatures";
 import { hexSchema } from "@/common/basic-schemas";
@@ -39,7 +36,7 @@ export async function loader({ request, params: remixParams }: LoaderFunctionArg
     throw notFound();
   }
 
-  let proposal = await getAndUpdateL2Cancellation(params.data.id);
+  const proposal = await getAndUpdateL2CancellationByExternalId(params.data.id);
 
   const [calls, signatures, guardiansAddr, l2GovernorAddr] = await Promise.all([
     getl2CancellationCallsByProposalId(proposal.id),

--- a/webapp/app/routes/app/l2-cancellations/$id/_route.tsx
+++ b/webapp/app/routes/app/l2-cancellations/$id/_route.tsx
@@ -23,7 +23,7 @@ import { badRequest, notFound } from "@/utils/http";
 import { env } from "@config/env.server";
 import { type ActionFunctionArgs, type LoaderFunctionArgs, json } from "@remix-run/node";
 import { useLoaderData } from "@remix-run/react";
-import { CircleCheckBig } from "lucide-react";
+import { CircleCheckBig, CircleX } from "lucide-react";
 import { getFormData, getParams } from "remix-params-helper";
 import { hexToBigInt, isAddressEqual } from "viem";
 import { z } from "zod";
@@ -202,6 +202,18 @@ export default function L2Cancellation() {
                 <p>Executed</p>
               </div>
             )}
+            {proposal.status === "NONCE_TOO_LOW" && (
+              <div className="flex flex-1 flex-col items-center justify-center space-y-2">
+                <CircleX className="h-16 w-16 stroke-red-500" />
+                <p>Nonce too low.</p>
+              </div>
+            )}
+            {proposal.status === "L2_PROPOSAL_EXPIRED" && (
+              <div className="flex flex-1 flex-col items-center justify-center space-y-2">
+                <CircleX className="h-16 w-16 stroke-red-500" />
+                <p>Proposal expired in l2</p>
+              </div>
+            )}
           </CardContent>
         </Card>
         <Card className="pb-10">
@@ -240,22 +252,27 @@ export default function L2Cancellation() {
             <CardTitle>Execute Actions</CardTitle>
           </CardHeader>
           <CardContent className="flex flex-col space-y-3">
-            <ExecL2VetoForm
-              proposalId={proposal.id}
-              guardiansAddress={guardiansAddress}
-              signatures={signatures}
-              threshold={necessarySignatures}
-              proposal={proposal}
-              disabled={execDisabled}
-              calls={calls}
-            >
-              Execute Veto
-            </ExecL2VetoForm>
+            {proposal.status === "ACTIVE" && (
+              <>
+                <ExecL2VetoForm
+                  proposalId={proposal.id}
+                  guardiansAddress={guardiansAddress}
+                  signatures={signatures}
+                  threshold={necessarySignatures}
+                  proposal={proposal}
+                  disabled={execDisabled}
+                  calls={calls}
+                >
+                  Execute Veto
+                </ExecL2VetoForm>
 
-            {!isExactNonce && (
-              <p className="text-red-500 text-s">
-                Nonce does not match with contract. Maybe some other veto has to be executed before.
-              </p>
+                {!isExactNonce && (
+                  <p className="text-red-500 text-s">
+                    Nonce does not match with contract. Maybe some other veto has to be executed
+                    before.
+                  </p>
+                )}
+              </>
             )}
           </CardContent>
         </Card>

--- a/webapp/app/routes/app/l2-cancellations/$id/_route.tsx
+++ b/webapp/app/routes/app/l2-cancellations/$id/_route.tsx
@@ -5,7 +5,7 @@ import {
 } from "@/.server/db/dto/l2-cancellations";
 import { getSignaturesByL2CancellationId } from "@/.server/db/dto/signatures";
 import { guardiansAddress } from "@/.server/service/contracts";
-import { getL2GovernorAddress } from "@/.server/service/l2-cancellations";
+import { getL2GovernorAddress, upgradeCancellationStatus } from "@/.server/service/l2-cancellations";
 import { validateAndSaveL2CancellationSignature } from "@/.server/service/signatures";
 import { hexSchema } from "@/common/basic-schemas";
 import HeaderWithBackButton from "@/components/proposal-header-with-back-button";
@@ -36,10 +36,12 @@ export async function loader({ request, params: remixParams }: LoaderFunctionArg
     throw notFound();
   }
 
-  const proposal = await getL2CancellationByExternalId(params.data.id);
+  let proposal = await getL2CancellationByExternalId(params.data.id);
   if (!proposal) {
     throw notFound();
   }
+
+  proposal = await upgradeCancellationStatus(proposal);
 
   const [calls, signatures, guardiansAddr, l2GovernorAddr] = await Promise.all([
     getl2CancellationCallsByProposalId(proposal.id),

--- a/webapp/app/routes/app/l2-cancellations/$id/_route.tsx
+++ b/webapp/app/routes/app/l2-cancellations/$id/_route.tsx
@@ -4,7 +4,8 @@ import { getSignaturesByL2CancellationId } from "@/.server/db/dto/signatures";
 import { guardiansAddress } from "@/.server/service/contracts";
 import {
   getAndUpdateL2CancellationByExternalId,
-  getL2GovernorAddress, getL2VetoNonce,
+  getL2GovernorAddress,
+  getL2VetoNonce,
 } from "@/.server/service/l2-cancellations";
 import { validateAndSaveL2CancellationSignature } from "@/.server/service/signatures";
 import { hexSchema } from "@/common/basic-schemas";
@@ -55,7 +56,7 @@ export async function loader({ request, params: remixParams }: LoaderFunctionArg
     guardiansAddress: guardiansAddr,
     l2GovernorAddress: l2GovernorAddr,
     ethNetwork: env.ETH_NETWORK,
-    currentNonce: await getL2VetoNonce()
+    currentNonce: await getL2VetoNonce(),
   });
 }
 
@@ -94,7 +95,7 @@ export default function L2Cancellation() {
     necessarySignatures,
     guardiansAddress,
     ethNetwork,
-    currentNonce
+    currentNonce,
   } = useLoaderData<typeof loader>();
 
   let proposalType: string;
@@ -112,7 +113,8 @@ export default function L2Cancellation() {
   const signDisabled =
     user.role !== "guardian" || signatures.some((s) => isAddressEqual(s.signer, user.address));
 
-  const execDisabled = signatures.length < necessarySignatures || proposal.transactionHash !== null || !isExactNonce;
+  const execDisabled =
+    signatures.length < necessarySignatures || proposal.transactionHash !== null || !isExactNonce;
 
   return (
     <div className="flex flex-1 flex-col">
@@ -139,9 +141,7 @@ export default function L2Cancellation() {
               </div>
               <div className="flex justify-between">
                 <span>Nonce:</span>
-                <span className="w-1/2 break-words text-right">
-                  {proposal.nonce}
-                </span>
+                <span className="w-1/2 break-words text-right">{proposal.nonce}</span>
               </div>
               <div className="flex justify-between">
                 <span>Veto L2 Gas Limit:</span>
@@ -175,8 +175,8 @@ export default function L2Cancellation() {
                 <div className="flex justify-between">
                   <span>Transaction Hash:</span>
                   <div className="flex flex-1 flex-col items-end space-y-1">
-                    <TxLink hash={proposal.transactionHash} network={ethNetwork}/>
-                    <TxStatus hash={proposal.transactionHash}/>
+                    <TxLink hash={proposal.transactionHash} network={ethNetwork} />
+                    <TxStatus hash={proposal.transactionHash} />
                   </div>
                 </div>
               )}
@@ -252,13 +252,12 @@ export default function L2Cancellation() {
               Execute Veto
             </ExecL2VetoForm>
 
-            { !isExactNonce && (
-              <p className="text-s text-red-500">
+            {!isExactNonce && (
+              <p className="text-red-500 text-s">
                 Nonce does not match with contract. Maybe some other veto has to be executed before.
               </p>
             )}
           </CardContent>
-
         </Card>
       </div>
 

--- a/webapp/app/routes/app/l2-cancellations/$id/_route.tsx
+++ b/webapp/app/routes/app/l2-cancellations/$id/_route.tsx
@@ -5,7 +5,10 @@ import {
 } from "@/.server/db/dto/l2-cancellations";
 import { getSignaturesByL2CancellationId } from "@/.server/db/dto/signatures";
 import { guardiansAddress } from "@/.server/service/contracts";
-import { getL2GovernorAddress, upgradeCancellationStatus } from "@/.server/service/l2-cancellations";
+import {
+  getAndUpdateL2Cancellation,
+  getL2GovernorAddress
+} from "@/.server/service/l2-cancellations";
 import { validateAndSaveL2CancellationSignature } from "@/.server/service/signatures";
 import { hexSchema } from "@/common/basic-schemas";
 import HeaderWithBackButton from "@/components/proposal-header-with-back-button";
@@ -36,12 +39,7 @@ export async function loader({ request, params: remixParams }: LoaderFunctionArg
     throw notFound();
   }
 
-  let proposal = await getL2CancellationByExternalId(params.data.id);
-  if (!proposal) {
-    throw notFound();
-  }
-
-  proposal = await upgradeCancellationStatus(proposal);
+  let proposal = await getAndUpdateL2Cancellation(params.data.id);
 
   const [calls, signatures, guardiansAddr, l2GovernorAddr] = await Promise.all([
     getl2CancellationCallsByProposalId(proposal.id),

--- a/webapp/app/routes/app/l2-cancellations/$id/write-transaction/_route.ts
+++ b/webapp/app/routes/app/l2-cancellations/$id/write-transaction/_route.ts
@@ -1,4 +1,5 @@
 import { getL2CancellationById, updateL2Cancellation } from "@/.server/db/dto/l2-cancellations";
+import { l2CancellationStatusEnum } from "@/.server/db/schema";
 import { hexSchema } from "@/common/basic-schemas";
 import { notFound } from "@/utils/http";
 import { type ActionFunctionArgs, redirect } from "@remix-run/node";
@@ -29,6 +30,7 @@ export async function action({ request, params: remixParams }: ActionFunctionArg
 
   await updateL2Cancellation(proposal.id, {
     transactionHash: data.data.hash,
+    status: l2CancellationStatusEnum.enum.DONE,
   });
 
   return redirect($path("/app/transactions/:hash", { hash: data.data.hash }));

--- a/webapp/app/routes/app/l2-cancellations/_index/_route.tsx
+++ b/webapp/app/routes/app/l2-cancellations/_index/_route.tsx
@@ -1,4 +1,4 @@
-import { getZkGovOpsProposals } from "@/.server/service/l2-cancellations";
+import { getUpdatedL2Cancellations } from "@/.server/service/l2-cancellations";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import {
@@ -16,7 +16,7 @@ import { ArrowRight } from "lucide-react";
 import { $path } from "remix-routes";
 
 export async function loader() {
-  const proposals = await getZkGovOpsProposals();
+  const proposals = await getUpdatedL2Cancellations();
   return json({ proposals });
 }
 

--- a/webapp/app/routes/app/l2-cancellations/_index/_route.tsx
+++ b/webapp/app/routes/app/l2-cancellations/_index/_route.tsx
@@ -14,7 +14,6 @@ import { json } from "@remix-run/node";
 import { Link, useLoaderData } from "@remix-run/react";
 import { ArrowRight } from "lucide-react";
 import { $path } from "remix-routes";
-import { l2CancellationStatusEnum } from "@/.server/db/schema";
 
 export async function loader() {
   const proposals = await getZkGovOpsProposals();
@@ -24,8 +23,8 @@ export async function loader() {
 export default function L2Proposals() {
   const { proposals } = useLoaderData<typeof loader>();
 
-  const activeProposals = proposals.filter((p) => p.status === l2CancellationStatusEnum.enum.ACTIVE);
-  const inactiveProposals = proposals.filter((p) => p.status !== l2CancellationStatusEnum.enum.ACTIVE);
+  const activeProposals = proposals.filter((p) => p.status === "ACTIVE");
+  const inactiveProposals = proposals.filter((p) => p.status !== "ACTIVE");
 
   return (
     <div className="space-y-4">

--- a/webapp/app/routes/app/l2-cancellations/_index/_route.tsx
+++ b/webapp/app/routes/app/l2-cancellations/_index/_route.tsx
@@ -14,6 +14,7 @@ import { json } from "@remix-run/node";
 import { Link, useLoaderData } from "@remix-run/react";
 import { ArrowRight } from "lucide-react";
 import { $path } from "remix-routes";
+import { l2CancellationStatusEnum } from "@/.server/db/schema";
 
 export async function loader() {
   const proposals = await getZkGovOpsProposals();
@@ -23,8 +24,8 @@ export async function loader() {
 export default function L2Proposals() {
   const { proposals } = useLoaderData<typeof loader>();
 
-  const activeProposals = proposals.filter((p) => p.transactionHash === null);
-  const inactiveProposals = proposals.filter((p) => p.transactionHash !== null);
+  const activeProposals = proposals.filter((p) => p.status === l2CancellationStatusEnum.enum.ACTIVE);
+  const inactiveProposals = proposals.filter((p) => p.status !== l2CancellationStatusEnum.enum.ACTIVE);
 
   return (
     <div className="space-y-4">

--- a/webapp/app/utils/l2-cancellation-states.ts
+++ b/webapp/app/utils/l2-cancellation-states.ts
@@ -9,8 +9,11 @@ export enum L2_CANCELLATION_STATES {
   Executed = 7,
 }
 
-export const VALID_CANCELLATION_STATES = [L2_CANCELLATION_STATES.Active, L2_CANCELLATION_STATES.Pending];
+export const VALID_CANCELLATION_STATES = [
+  L2_CANCELLATION_STATES.Active,
+  L2_CANCELLATION_STATES.Pending,
+];
 
 export function isValidCancellationState(state: L2_CANCELLATION_STATES | undefined): boolean {
-  return VALID_CANCELLATION_STATES.some(s => s === state);
+  return VALID_CANCELLATION_STATES.some((s) => s === state);
 }

--- a/webapp/app/utils/l2-cancellation-states.ts
+++ b/webapp/app/utils/l2-cancellation-states.ts
@@ -1,4 +1,4 @@
-export enum L2_CANCELATION_STATES {
+export enum L2_CANCELLATION_STATES {
   Pending = 0,
   Active = 1,
   Canceled = 2,
@@ -7,4 +7,10 @@ export enum L2_CANCELATION_STATES {
   Queued = 5,
   Expired = 6,
   Executed = 7,
+}
+
+export const VALID_CANCELLATION_STATES = [L2_CANCELLATION_STATES.Active, L2_CANCELLATION_STATES.Pending];
+
+export function isValidCancellationState(state: L2_CANCELLATION_STATES | undefined): boolean {
+  return VALID_CANCELLATION_STATES.some(s => s === state);
 }


### PR DESCRIPTION
Changes:

- Updating cancellation status on /cancellations/ route
- Updating cancellation status on /cancellations/:d route
- Added option to manually set proposal nonce.
- avoid users to select a nonce lower than the one in the contract
- failing if nonce is already used in an active proposal