### PR TITLE
Fix big number issues in l2 cancellation creation

### DIFF
--- a/cli/test/block-explorer-client.spec.ts
+++ b/cli/test/block-explorer-client.spec.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it } from "vitest";
 import { BlockExplorerClient } from "../src";
 import { ExternalApiError } from "../src/lib/errors";
 
-describe("BlockExplorerClient", () => {
+describe.skip("BlockExplorerClient", () => {
   describe("#getAbi", () => {
     describe("ok with a working api", () => {
       const subject = () =>

--- a/cli/test/block-explorer-client.spec.ts
+++ b/cli/test/block-explorer-client.spec.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it } from "vitest";
 import { BlockExplorerClient } from "../src";
 import { ExternalApiError } from "../src/lib/errors";
 
-describe.skip("BlockExplorerClient", () => {
+describe("BlockExplorerClient", () => {
   describe("#getAbi", () => {
     describe("ok with a working api", () => {
       const subject = () =>

--- a/webapp/app/common/basic-schemas.ts
+++ b/webapp/app/common/basic-schemas.ts
@@ -10,10 +10,7 @@ export const addressSchema = hexChars
   .refine((str) => str.length === 42, "Address have to be 20 bytes long")
   .transform((str) => getAddress(str));
 
-export const numericStrSchema = z.coerce
+export const nonZeroNumericStrSchema = z.coerce
   .bigint({ message: "Must be a integer number" })
+  .refine(num => num !== 0n, { message: "Cannot be zero" })
   .transform((num) => num.toString());
-
-export const nonZeroNumericStrSchema = numericStrSchema.refine((s) => !/^0+$/.test(s), {
-  message: "Cannot be zero.",
-});

--- a/webapp/app/common/basic-schemas.ts
+++ b/webapp/app/common/basic-schemas.ts
@@ -12,5 +12,5 @@ export const addressSchema = hexChars
 
 export const nonZeroNumericStrSchema = z.coerce
   .bigint({ message: "Must be a integer number" })
-  .refine(num => num !== 0n, { message: "Cannot be zero" })
+  .refine((num) => num !== 0n, { message: "Cannot be zero" })
   .transform((num) => num.toString());

--- a/webapp/app/common/basic-schemas.ts
+++ b/webapp/app/common/basic-schemas.ts
@@ -10,7 +10,7 @@ export const addressSchema = hexChars
   .refine((str) => str.length === 42, "Address have to be 20 bytes long")
   .transform((str) => getAddress(str));
 
-export const nonZeroNumericStrSchema = z.coerce
+export const nonZeroBigIntStrSchema = z.coerce
   .bigint({ message: "Must be a integer number" })
   .refine((num) => num !== 0n, { message: "Cannot be zero" })
   .transform((num) => num.toString());

--- a/webapp/app/common/basic-schemas.ts
+++ b/webapp/app/common/basic-schemas.ts
@@ -2,6 +2,7 @@ import { type Hex, getAddress } from "viem";
 import { z } from "zod";
 
 const hexRegexp = /^0x[0-9a-fA-F]*$/;
+const numericalStrRegex = /^[0-9]+$/;
 
 const hexChars = z.string().refine((str) => hexRegexp.test(str), "Not a valid hex");
 
@@ -9,3 +10,11 @@ export const hexSchema = hexChars.transform((str) => str as Hex);
 export const addressSchema = hexChars
   .refine((str) => str.length === 42, "Address have to be 20 bytes long")
   .transform((str) => getAddress(str));
+
+export const numericStrSchema = z
+  .string()
+  .regex(numericalStrRegex, { message: "Must be a number" });
+
+export const nonZeroNumericStrSchema = numericStrSchema.refine((s) => !/^0+$/.test(s), {
+  message: "Cannot be zero.",
+});

--- a/webapp/app/common/basic-schemas.ts
+++ b/webapp/app/common/basic-schemas.ts
@@ -2,7 +2,6 @@ import { type Hex, getAddress } from "viem";
 import { z } from "zod";
 
 const hexRegexp = /^0x[0-9a-fA-F]*$/;
-const numericalStrRegex = /^[0-9]+$/;
 
 const hexChars = z.string().refine((str) => hexRegexp.test(str), "Not a valid hex");
 
@@ -11,9 +10,9 @@ export const addressSchema = hexChars
   .refine((str) => str.length === 42, "Address have to be 20 bytes long")
   .transform((str) => getAddress(str));
 
-export const numericStrSchema = z
-  .string()
-  .regex(numericalStrRegex, { message: "Must be a number" });
+export const numericStrSchema = z.coerce
+  .bigint({ message: "Must be a integer number" })
+  .transform((num) => num.toString());
 
 export const nonZeroNumericStrSchema = numericStrSchema.refine((s) => !/^0+$/.test(s), {
   message: "Cannot be zero.",

--- a/webapp/app/routes/app/emergency/$id/_route.tsx
+++ b/webapp/app/routes/app/emergency/$id/_route.tsx
@@ -25,13 +25,14 @@ import {
   SEC_COUNCIL_THRESHOLD,
   ZK_FOUNDATION_THRESHOLD,
 } from "@/utils/emergency-proposals";
+import { extract } from "@/utils/extract-from-formdata";
 import { badRequest, notFound } from "@/utils/http";
 import { type ActionFunctionArgs, type LoaderFunctionArgs, json } from "@remix-run/node";
 import { useLoaderData } from "@remix-run/react";
 import { getParams } from "remix-params-helper";
 import { $path } from "remix-routes";
 import { type Hex, isAddressEqual } from "viem";
-import { type ZodTypeAny, z } from "zod";
+import { z } from "zod";
 
 export async function loader(args: LoaderFunctionArgs) {
   const user = requireUserFromHeader(args.request);
@@ -72,19 +73,6 @@ export async function loader(args: LoaderFunctionArgs) {
     allGuardians: await guardianMembers(),
     allSecurityCouncil: await councilMembers(),
   });
-}
-
-function extract<T extends ZodTypeAny>(
-  formData: FormData,
-  key: string,
-  parser: T
-): z.infer<typeof parser> {
-  const value = formData.get(key);
-  const parsed = parser.safeParse(value);
-  if (parsed.error) {
-    throw badRequest(`Wrong value for ${key}`);
-  }
-  return parsed.data;
 }
 
 const intentParser = z.enum(["newSignature", "broadcastSuccess"]);

--- a/webapp/app/routes/app/l2-cancellations/new/_route.tsx
+++ b/webapp/app/routes/app/l2-cancellations/new/_route.tsx
@@ -4,7 +4,7 @@ import {
   getActiveL2Proposals,
   getL2VetoNonce,
 } from "@/.server/service/l2-cancellations";
-import { addressSchema, hexSchema } from "@/common/basic-schemas";
+import { addressSchema, hexSchema, nonZeroNumericStrSchema } from "@/common/basic-schemas";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import {
@@ -26,6 +26,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
+import { extract } from "@/utils/extract-from-formdata";
 import { badRequest } from "@/utils/http";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { type ActionFunctionArgs, defer, redirect } from "@remix-run/node";
@@ -33,7 +34,6 @@ import { Await, useLoaderData, useNavigation } from "@remix-run/react";
 import { Form as RemixForm } from "@remix-run/react";
 import { Suspense } from "react";
 import { useForm } from "react-hook-form";
-import { getFormData } from "remix-params-helper";
 import { $path } from "remix-routes";
 import { numberToHex } from "viem";
 import { useAccount } from "wagmi";
@@ -51,39 +51,34 @@ export async function loader() {
 }
 
 export async function action({ request }: ActionFunctionArgs) {
-  const parsed = await getFormData(
-    request,
-    z.object({
-      proposalId: hexSchema,
-      l2GasLimit: z.coerce.number(),
-      l2GasPerPubdataByteLimit: z.coerce.number(),
-      refundRecipient: addressSchema,
-      txMintValue: z.coerce.number(),
-      nonce: z.coerce.number(),
-    })
-  );
-  if (!parsed.success) {
-    throw badRequest(`Failed to parse body: ${parsed.errors}`);
-  }
+  const formData = await request.formData().catch(() => {
+    throw badRequest("Failed to parse body");
+  });
+
+  const proposalId = extract(formData, "proposalId", hexSchema);
+  const l2GasLimit = extract(formData, "l2GasLimit", z.coerce.bigint());
+  const l2GasPerPubdataByteLimit = extract(formData, "l2GasPerPubdataByteLimit", z.coerce.bigint());
+  const refundRecipient = extract(formData, "refundRecipient", addressSchema);
+  const txMintValue = extract(formData, "txMintValue", z.coerce.bigint());
+  const nonce = extract(formData, "nonce", z.coerce.number());
+
   await createVetoProposalFor(
-    parsed.data.proposalId,
-    numberToHex(parsed.data.l2GasLimit),
-    numberToHex(parsed.data.l2GasPerPubdataByteLimit),
-    parsed.data.refundRecipient,
-    numberToHex(parsed.data.txMintValue),
-    parsed.data.nonce
+    proposalId,
+    numberToHex(l2GasLimit),
+    numberToHex(l2GasPerPubdataByteLimit),
+    refundRecipient,
+    numberToHex(txMintValue),
+    nonce
   );
   return redirect($path("/app/l2-cancellations"));
 }
 
 const schema = z.object({
   proposalId: hexSchema,
-  l2GasLimit: z.coerce.number({ message: "L2 Gas Limit must be a number" }),
-  l2GasPerPubdataByteLimit: z.coerce.number({
-    message: "L2 Gas per pubdata byte limit must be a number",
-  }),
+  l2GasLimit: nonZeroNumericStrSchema,
+  l2GasPerPubdataByteLimit: nonZeroNumericStrSchema,
   refundRecipient: addressSchema,
-  txMintValue: z.coerce.number({ message: "Transaction mint value must be a number" }),
+  txMintValue: nonZeroNumericStrSchema,
   nonce: z.coerce.number({ message: "Nonce value must be a number" }),
 });
 type Schema = z.infer<typeof schema>;
@@ -99,10 +94,10 @@ export default function NewL2GovernorVeto() {
     ),
     defaultValues: {
       nonce: suggestedNonce,
-      l2GasLimit: 80000000,
-      l2GasPerPubdataByteLimit: 800,
+      l2GasLimit: "80000000",
+      l2GasPerPubdataByteLimit: "800",
       refundRecipient: address,
-      txMintValue: 1000000000000000,
+      txMintValue: "1000000000000000",
     },
     mode: "onTouched",
   });

--- a/webapp/app/routes/app/l2-cancellations/new/_route.tsx
+++ b/webapp/app/routes/app/l2-cancellations/new/_route.tsx
@@ -4,7 +4,7 @@ import {
   getActiveL2Proposals,
   getL2VetoNonce,
 } from "@/.server/service/l2-cancellations";
-import { addressSchema, hexSchema, nonZeroNumericStrSchema } from "@/common/basic-schemas";
+import { addressSchema, hexSchema, nonZeroBigIntStrSchema } from "@/common/basic-schemas";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import {
@@ -75,10 +75,10 @@ export async function action({ request }: ActionFunctionArgs) {
 
 const schema = z.object({
   proposalId: hexSchema,
-  l2GasLimit: nonZeroNumericStrSchema,
-  l2GasPerPubdataByteLimit: nonZeroNumericStrSchema,
+  l2GasLimit: nonZeroBigIntStrSchema,
+  l2GasPerPubdataByteLimit: nonZeroBigIntStrSchema,
   refundRecipient: addressSchema,
-  txMintValue: nonZeroNumericStrSchema,
+  txMintValue: nonZeroBigIntStrSchema,
   nonce: z.coerce.number({ message: "Nonce value must be a number" }),
 });
 type Schema = z.infer<typeof schema>;

--- a/webapp/app/utils/extract-from-formdata.ts
+++ b/webapp/app/utils/extract-from-formdata.ts
@@ -1,0 +1,15 @@
+import { badRequest } from "@/utils/http";
+import type { ZodTypeAny, z } from "zod";
+
+export function extract<T extends ZodTypeAny>(
+  formData: FormData,
+  key: string,
+  parser: T
+): z.infer<typeof parser> {
+  const value = formData.get(key);
+  const parsed = parser.safeParse(value);
+  if (parsed.error) {
+    throw badRequest(`Wrong value for ${key}`);
+  }
+  return parsed.data;
+}


### PR DESCRIPTION
Parsing of really big numbers was failing in a few places of the new cancellation flow. Changes made:

- Avoid using "number" type in every part of the flow. Instead using bigint or numerical strings.
- Avoid bigints with remix-params-helper. There is a bug there that makes it fail. Instead using simple custom function to extract data. 

