### PR TITLE
Fixed account nonce out of data

### DIFF
--- a/packages/e2e/suites/full/emergency-upgrade.spec.ts
+++ b/packages/e2e/suites/full/emergency-upgrade.spec.ts
@@ -4,12 +4,13 @@ import type { Dappwright, Dappwright as Wallet } from "@tenkeylabs/dappwright";
 import { TestApp } from "./helpers/test-app.js";
 import { councilRange, guardianRange, repeatFor } from "./helpers/utils.js";
 
-const testApp = new TestApp();
-
-test.beforeEach(async ({ page }) => {
+test.beforeEach(async ({ testApp }) => {
   await testApp.reset();
-  await page.goto("/");
 });
+
+test.afterEach(async ({ clearWalletNonces }) => {
+  await clearWalletNonces()
+})
 
 async function goToEmergencyIndex(page: Page) {
   await page.goto("/");
@@ -96,16 +97,16 @@ test("TC202: Create a valid emergency proposal -> List it into active proposals"
 }) => {
   await createEmergencyProposal(page, "TC202");
   await goToEmergencyIndex(page);
-  await page.getByText("title").isVisible();
+  await page.getByText("title").waitFor();
   const rows = await page.locator("tbody tr").all();
   expect(rows.length).toBe(1);
   const row = rows[0];
   if (row === undefined) {
     throw new Error("Missing row with created upgraded.");
   }
-  await row.getByText("TC202").isVisible();
-  await row.getByText("ACTIVE").isVisible();
-  await row.getByText("View").isVisible();
+  await expect(row.getByText("TC202")).toBeVisible();
+  await expect(row.getByText("ACTIVE")).toBeVisible();
+  await expect(row.getByText("View")).toBeVisible();
 });
 
 test("TC203: Try to create emergency upgrade with invalid calldata -> Cannot be done. Shows error message.", async ({

--- a/packages/e2e/suites/full/emergency-upgrade.spec.ts
+++ b/packages/e2e/suites/full/emergency-upgrade.spec.ts
@@ -1,16 +1,11 @@
 import { expect, type RoleSwitcher, test } from "./helpers/dappwright.js";
 import type { Page } from "@playwright/test";
 import type { Dappwright, Dappwright as Wallet } from "@tenkeylabs/dappwright";
-import { TestApp } from "./helpers/test-app.js";
 import { councilRange, guardianRange, repeatFor } from "./helpers/utils.js";
 
 test.beforeEach(async ({ testApp }) => {
   await testApp.reset();
 });
-
-test.afterEach(async ({ clearWalletNonces }) => {
-  await clearWalletNonces()
-})
 
 async function goToEmergencyIndex(page: Page) {
   await page.goto("/");

--- a/packages/e2e/suites/full/freeze.spec.ts
+++ b/packages/e2e/suites/full/freeze.spec.ts
@@ -7,10 +7,6 @@ test.beforeEach(async ({ testApp }) => {
   await testApp.reset();
 });
 
-test.afterEach(async ({ clearWalletNonces }) => {
-  await clearWalletNonces()
-})
-
 async function goToFreezeIndex(page: Page) {
   await page.goto("/");
   await page.getByText("Freeze Requests").click();

--- a/packages/e2e/suites/full/freeze.spec.ts
+++ b/packages/e2e/suites/full/freeze.spec.ts
@@ -2,13 +2,14 @@ import { expect, type IntRange, type RoleSwitcher, test } from "./helpers/dappwr
 import type { Page } from "@playwright/test";
 import type { Dappwright as Wallet } from "@tenkeylabs/dappwright";
 import type { COUNCIL_SIZE } from "@repo/contracts/helpers/constants";
-import { TestApp } from "./helpers/test-app.js";
 
-const testApp = new TestApp();
-
-test.beforeEach(async () => {
+test.beforeEach(async ({ testApp }) => {
   await testApp.reset();
 });
+
+test.afterEach(async ({ clearWalletNonces }) => {
+  await clearWalletNonces()
+})
 
 async function goToFreezeIndex(page: Page) {
   await page.goto("/");

--- a/packages/e2e/suites/full/helpers/dappwright.ts
+++ b/packages/e2e/suites/full/helpers/dappwright.ts
@@ -24,11 +24,17 @@ let sharedBrowserContext: BrowserContext;
 // Fast mode limits the number of accounts created to 1 per role
 const fastMode = process.env.TEST_FAST_MODE === "true";
 
+type ChangeAccountFn = () => Promise<void>;
+
 export class RoleSwitcher {
   private wallet: Dappwright;
+  private history: ChangeAccountFn[];
+  private current: ChangeAccountFn | null;
 
   constructor(wallet: Dappwright) {
     this.wallet = wallet;
+    this.history = [];
+    this.current = null
   }
 
   async council(councilNumber: IntRange<1, typeof COUNCIL_SIZE>, page?: Page) {
@@ -36,6 +42,7 @@ export class RoleSwitcher {
       throw new Error("Fast mode does not support council numbers other than 1");
     }
     const index = COUNCIL_INDEXES[councilNumber - 1] as number;
+    this.current = async () => this.council(councilNumber);
     await this.switchToIndex(index, page);
   }
 
@@ -44,15 +51,31 @@ export class RoleSwitcher {
       throw new Error("Fast mode does not support guardian numbers other than 1");
     }
     const index = GUARDIAN_INDEXES[guardianNumber - 1] as number;
+    this.current = async () => this.guardian(guardianNumber);
     await this.switchToIndex(index, page);
   }
 
   async zkFoundation(page?: Page) {
+    this.current = async () => this.zkFoundation();
     await this.switchToIndex(DERIVATION_INDEXES.ZK_FOUNDATION, page);
   }
 
   async visitor(page?: Page) {
+    this.current = async () => this.visitor();
     await this.switchToIndex(DERIVATION_INDEXES.VISITOR, page);
+  }
+
+  pushToHistory(): void {
+    if (this.current === null) {
+      throw new Error("Cannot push to history if no account is set.")
+    }
+    this.history.push(this.current)
+  }
+
+  popHistory(): ChangeAccountFn[] {
+    const res = this.history
+    this.history = []
+    return res;
   }
 
   private async switchToIndex(index: number, page?: Page) {
@@ -62,18 +85,18 @@ export class RoleSwitcher {
   }
 }
 
-let testApp: TestApp;
+const testApp = new TestApp();
 
 export const test = baseTest.extend<{
   context: BrowserContext;
   wallet: Dappwright;
   switcher: RoleSwitcher;
+  testApp: TestApp;
+  clearWalletNonces: () => Promise<void>
 }>({
   // biome-ignore lint/correctness/noEmptyPattern: <explanation>
   context: async ({}, use) => {
     if (!sharedBrowserContext) {
-      testApp = new TestApp();
-
       // Launch context with extension
 
       // `dappwright.launch` is used to be able to modify the
@@ -135,6 +158,7 @@ export const test = baseTest.extend<{
       // Reset waitForTimeout method
       wallet.page.waitForTimeout = originalWaitForTimeout;
     }
+``
     await use(sharedBrowserContext);
   },
 
@@ -153,6 +177,36 @@ export const test = baseTest.extend<{
   },
 
   switcher: async ({ wallet }, use) => {
-    await use(new RoleSwitcher(wallet));
+    const switcher = new RoleSwitcher(wallet);
+
+    const original = wallet.confirmTransaction;
+    wallet.confirmTransaction = async () => {
+      switcher.pushToHistory();
+      await original.bind(wallet)();
+    }
+
+    await use(switcher);
   },
+
+  testApp: async ({}, use) => {
+    await use(testApp)
+  },
+
+  clearWalletNonces: async ({ wallet, switcher, page }, use) => {
+    await use(async () => {
+      const history = switcher.popHistory()
+      for (const entry of history) {
+        await entry()
+
+        await wallet.page.bringToFront();
+        await wallet.page.getByTestId('account-options-menu-button').click();
+        await wallet.page.getByTestId('global-menu-settings').click();
+        await wallet.page.getByText("Advanced").click();
+        await wallet.page.getByText("Clear activity tab data").click();
+        await wallet.page.getByRole("button", { name: "Clear", exact: true }).click();
+        await wallet.page.locator(".app-header__logo-container").click();
+      }
+      await page.bringToFront();
+    })
+  }
 });

--- a/packages/e2e/suites/full/helpers/dappwright.ts
+++ b/packages/e2e/suites/full/helpers/dappwright.ts
@@ -26,7 +26,6 @@ const fastMode = process.env.TEST_FAST_MODE === "true";
 
 type ChangeAccountFn = () => Promise<void>;
 
-
 export class RoleSwitcher {
   private wallet: Dappwright;
   private history: ChangeAccountFn[];
@@ -35,7 +34,7 @@ export class RoleSwitcher {
   constructor(wallet: Dappwright) {
     this.wallet = wallet;
     this.history = [];
-    this.current = null
+    this.current = null;
   }
 
   async council(councilNumber: IntRange<1, typeof COUNCIL_SIZE>, page?: Page) {
@@ -68,14 +67,14 @@ export class RoleSwitcher {
 
   pushToHistory(): void {
     if (this.current === null) {
-      throw new Error("Cannot push to history if no account is set.")
+      throw new Error("Cannot push to history if no account is set.");
     }
-    this.history.push(this.current)
+    this.history.push(this.current);
   }
 
   popHistory(): ChangeAccountFn[] {
-    const res = this.history
-    this.history = []
+    const res = this.history;
+    this.history = [];
     return res;
   }
 
@@ -184,7 +183,7 @@ export const test = baseTest.extend<{
     wallet.confirmTransaction = async () => {
       switcher.pushToHistory();
       await original.bind(wallet)();
-    }
+    };
 
     await use(switcher);
 
@@ -192,22 +191,23 @@ export const test = baseTest.extend<{
     // Clear the tx nonce in metamask.
     // This is because metamask doesn't automatically fix the nonce when it doesn't
     // match with the network. Doing this forces metamask to refresh the nonce.
-    const history = switcher.popHistory()
+    const history = switcher.popHistory();
     for (const entry of history) {
-      await entry()
+      await entry();
 
       await wallet.page.bringToFront();
-      await wallet.page.getByTestId('account-options-menu-button').click();
-      await wallet.page.getByTestId('global-menu-settings').click();
+      await wallet.page.getByTestId("account-options-menu-button").click();
+      await wallet.page.getByTestId("global-menu-settings").click();
       await wallet.page.getByText("Advanced").click();
       await wallet.page.getByText("Clear activity tab data").click();
-      await wallet.page.getByRole("button", {name: "Clear", exact: true}).click();
+      await wallet.page.getByRole("button", { name: "Clear", exact: true }).click();
       await wallet.page.locator(".app-header__logo-container").click();
     }
-    await page.bringToFront()
+    await page.bringToFront();
   },
 
+  // biome-ignore lint/correctness/noEmptyPattern: playwright fixtures require explicit empty pattern
   testApp: async ({}, use) => {
-    await use(testApp)
-  }
+    await use(testApp);
+  },
 });

--- a/packages/e2e/suites/full/l2-cancellations.spec.ts
+++ b/packages/e2e/suites/full/l2-cancellations.spec.ts
@@ -1,4 +1,3 @@
-import { TestApp } from "./helpers/test-app.js";
 import { expect, type RoleSwitcher, test } from "./helpers/dappwright.js";
 import type { Page } from "@playwright/test";
 import type { Dappwright as Wallet } from "@tenkeylabs/dappwright";
@@ -7,10 +6,6 @@ import { guardianRange, repeatFor } from "./helpers/utils.js";
 test.beforeEach(async ({ testApp }) => {
   await testApp.reset();
 });
-
-test.afterEach(async ({ clearWalletNonces }) => {
-  await clearWalletNonces()
-})
 
 async function goToCancellationsIndex(page: Page) {
   await page.goto("/");

--- a/packages/e2e/suites/full/l2-cancellations.spec.ts
+++ b/packages/e2e/suites/full/l2-cancellations.spec.ts
@@ -4,11 +4,13 @@ import type { Page } from "@playwright/test";
 import type { Dappwright as Wallet } from "@tenkeylabs/dappwright";
 import { guardianRange, repeatFor } from "./helpers/utils.js";
 
-const testApp = new TestApp();
-
-test.beforeEach(async () => {
+test.beforeEach(async ({ testApp }) => {
   await testApp.reset();
 });
+
+test.afterEach(async ({ clearWalletNonces }) => {
+  await clearWalletNonces()
+})
 
 async function goToCancellationsIndex(page: Page) {
   await page.goto("/");

--- a/packages/e2e/suites/full/landing.spec.ts
+++ b/packages/e2e/suites/full/landing.spec.ts
@@ -1,11 +1,13 @@
 import { test, expect } from "./helpers/dappwright.js";
 import { TestApp } from "./helpers/test-app.js";
 
-const testApp = new TestApp();
-
-test.beforeEach(async () => {
+test.beforeEach(async ({ testApp }) => {
   await testApp.reset();
 });
+
+test.afterEach(async ({ clearWalletNonces }) => {
+  await clearWalletNonces()
+})
 
 test("TC100 - Login as visitor", async ({ switcher, page }) => {
   await switcher.visitor(page);
@@ -27,14 +29,14 @@ test("TC103 - Login as zk foundation", async ({ switcher, page }) => {
   await expect(page.getByTestId("user-role")).toHaveText("ZkSync Foundation");
 });
 
-test("TC104 - View all buttons in private app", async ({ page }) => {
+test("TC104 - View all buttons in private app", async ({ page, testApp }) => {
   await expect(page.getByText("Standard Upgrades")).toBeVisible();
   await expect(page.getByText("Emergency Upgrades")).toBeVisible();
   await expect(page.getByText("Freeze Requests")).toBeVisible();
   await expect(page.getByText("L2 Proposals Veto")).toBeVisible();
 });
 
-test("TC105 - View only standard upgrades in private app", async ({ page }) => {
+test.skip("TC105 - View only standard upgrades in private app", async ({ page, testApp }) => {
   await testApp.resetApp({ env: { ALLOW_PRIVATE_ACTIONS: "false" } });
 
   await expect(page.getByText("Standard Upgrades")).toBeVisible();

--- a/packages/e2e/suites/full/landing.spec.ts
+++ b/packages/e2e/suites/full/landing.spec.ts
@@ -1,13 +1,8 @@
 import { test, expect } from "./helpers/dappwright.js";
-import { TestApp } from "./helpers/test-app.js";
 
-test.beforeEach(async ({ testApp }) => {
+test.beforeEach(async ({ testApp}) => {
   await testApp.reset();
 });
-
-test.afterEach(async ({ clearWalletNonces }) => {
-  await clearWalletNonces()
-})
 
 test("TC100 - Login as visitor", async ({ switcher, page }) => {
   await switcher.visitor(page);
@@ -36,7 +31,7 @@ test("TC104 - View all buttons in private app", async ({ page, testApp }) => {
   await expect(page.getByText("L2 Proposals Veto")).toBeVisible();
 });
 
-test.skip("TC105 - View only standard upgrades in private app", async ({ page, testApp }) => {
+test("TC105 - View only standard upgrades in private app", async ({ page, testApp }) => {
   await testApp.resetApp({ env: { ALLOW_PRIVATE_ACTIONS: "false" } });
 
   await expect(page.getByText("Standard Upgrades")).toBeVisible();

--- a/packages/e2e/suites/full/landing.spec.ts
+++ b/packages/e2e/suites/full/landing.spec.ts
@@ -34,6 +34,7 @@ test("TC104 - View all buttons in private app", async ({ page }) => {
 test("TC105 - View only standard upgrades in private app", async ({ testApp, context }) => {
   try {
     await testApp.resetApp({ env: { ALLOW_PRIVATE_ACTIONS: "false" } });
+    // We use a new page here to ensure that we render everything using the new configuration of the app.
     const page = await context.newPage();
     await page.goto("/");
     try {
@@ -42,9 +43,11 @@ test("TC105 - View only standard upgrades in private app", async ({ testApp, con
       await expect(page.getByText("Freeze Requests")).not.toBeVisible();
       await expect(page.getByText("L2 Proposals Veto")).not.toBeVisible();
     } finally {
+      // Ensuring that this page is always closed, even if the test fails.
       await page.close();
     }
   } finally {
+    // Ensuring that we get back the original configuration, even if the test fails.
     await testApp.resetApp({ env: { ALLOW_PRIVATE_ACTIONS: "true" } });
   }
 });

--- a/packages/e2e/suites/full/landing.spec.ts
+++ b/packages/e2e/suites/full/landing.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from "./helpers/dappwright.js";
 
-test.beforeEach(async ({ testApp}) => {
+test.beforeEach(async ({ testApp }) => {
   await testApp.reset();
 });
 

--- a/packages/e2e/suites/full/landing.spec.ts
+++ b/packages/e2e/suites/full/landing.spec.ts
@@ -24,20 +24,27 @@ test("TC103 - Login as zk foundation", async ({ switcher, page }) => {
   await expect(page.getByTestId("user-role")).toHaveText("ZkSync Foundation");
 });
 
-test("TC104 - View all buttons in private app", async ({ page, testApp }) => {
+test("TC104 - View all buttons in private app", async ({ page }) => {
   await expect(page.getByText("Standard Upgrades")).toBeVisible();
   await expect(page.getByText("Emergency Upgrades")).toBeVisible();
   await expect(page.getByText("Freeze Requests")).toBeVisible();
   await expect(page.getByText("L2 Proposals Veto")).toBeVisible();
 });
 
-test("TC105 - View only standard upgrades in private app", async ({ page, testApp }) => {
-  await testApp.resetApp({ env: { ALLOW_PRIVATE_ACTIONS: "false" } });
-
-  await expect(page.getByText("Standard Upgrades")).toBeVisible();
-  await expect(page.getByText("Emergency Upgrades")).not.toBeVisible();
-  await expect(page.getByText("Freeze Requests")).not.toBeVisible();
-  await expect(page.getByText("L2 Proposals Veto")).not.toBeVisible();
-
-  await testApp.resetApp({ env: { ALLOW_PRIVATE_ACTIONS: "true" } });
+test("TC105 - View only standard upgrades in private app", async ({ testApp, context }) => {
+  try {
+    await testApp.resetApp({ env: { ALLOW_PRIVATE_ACTIONS: "false" } });
+    const page = await context.newPage();
+    await page.goto("/");
+    try {
+      await expect(page.getByText("Standard Upgrades")).toBeVisible();
+      await expect(page.getByText("Emergency Upgrades")).not.toBeVisible();
+      await expect(page.getByText("Freeze Requests")).not.toBeVisible();
+      await expect(page.getByText("L2 Proposals Veto")).not.toBeVisible();
+    } finally {
+      await page.close();
+    }
+  } finally {
+    await testApp.resetApp({ env: { ALLOW_PRIVATE_ACTIONS: "true" } });
+  }
 });


### PR DESCRIPTION
Metamask does not reset their nonce when the network reset. This is doing clearing the nonce by hand, but only for the accounts that actually changed.